### PR TITLE
✨ feat: 경로 조회 , 경로 내 장소 목록 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,12 @@ dependencies {
     // PostgreSql
     runtimeOnly 'org.postgresql:postgresql'
 
+    // Hibernate Spatial
+    implementation 'org.hibernate:hibernate-spatial:6.2.6.Final'
+
+    // JTS 라이브러리
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
+
     // Lombok
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/project/nupibe/domain/route/controller/RouteController.java
+++ b/src/main/java/com/project/nupibe/domain/route/controller/RouteController.java
@@ -1,6 +1,7 @@
 package com.project.nupibe.domain.route.controller;
 
-import com.project.nupibe.domain.route.dto.response.RouteResDTO;
+import com.project.nupibe.domain.route.dto.response.RouteDetailResDTO;
+import com.project.nupibe.domain.route.dto.response.RoutePlacesResDTO;
 import com.project.nupibe.domain.route.service.query.RouteQueryService;
 import com.project.nupibe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,8 +22,15 @@ public class RouteController {
 
     @GetMapping("/{routeId}")
     @Operation(summary = "경로 상세 조회 API", description = "PathVariable로 보낸 id의 경로를 상세 조회 합니다.")
-    public CustomResponse<RouteResDTO.RouteDetailResponse> getRouteDetail(@PathVariable Long routeId) {
-        RouteResDTO.RouteDetailResponse response = routeQueryService.getRouteDetail(routeId);
+    public CustomResponse<RouteDetailResDTO.RouteDetailResponse> getRouteDetail(@PathVariable Long routeId) {
+        RouteDetailResDTO.RouteDetailResponse response = routeQueryService.getRouteDetail(routeId);
+        return CustomResponse.onSuccess(response);
+    }
+
+    @GetMapping("/{routeId}/stores")
+    @Operation(summary = "경로 내 장소 목록 조회 API", description = "PathVariable로 보낸 id의 경로 내 장소들을 조회 합니다.")
+    public CustomResponse<RoutePlacesResDTO.RoutePlacesResponse> getRoutePlaces(@PathVariable Long routeId) {
+        RoutePlacesResDTO.RoutePlacesResponse response = routeQueryService.getRoutePlaces(routeId);
         return CustomResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/project/nupibe/domain/route/controller/RouteController.java
+++ b/src/main/java/com/project/nupibe/domain/route/controller/RouteController.java
@@ -1,0 +1,28 @@
+package com.project.nupibe.domain.route.controller;
+
+import com.project.nupibe.domain.route.dto.response.RouteResDTO;
+import com.project.nupibe.domain.route.service.query.RouteQueryService;
+import com.project.nupibe.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/routes")
+@Tag(name = "경로 API", description = "경로 관련 CRUD 및 기능 API")
+public class RouteController {
+
+    private final RouteQueryService routeQueryService;
+
+    @GetMapping("/{routeId}")
+    @Operation(summary = "경로 상세 조회 API", description = "PathVariable로 보낸 id의 경로를 상세 조회 합니다.")
+    public CustomResponse<RouteResDTO.RouteDetailResponse> getRouteDetail(@PathVariable Long routeId) {
+        RouteResDTO.RouteDetailResponse response = routeQueryService.getRouteDetail(routeId);
+        return CustomResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/project/nupibe/domain/route/converter/RouteConverter.java
+++ b/src/main/java/com/project/nupibe/domain/route/converter/RouteConverter.java
@@ -38,7 +38,7 @@ public class RouteConverter {
                         .location(place.location())
                         .category(place.category())
                         .order(place.orderIndex())
-                        .distance(place.distance())
+                        .distance(place.distance() != null ? place.distance() : "첫번째장소") // distance가 null이면 "첫번째장소"로 처리
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/project/nupibe/domain/route/converter/RouteConverter.java
+++ b/src/main/java/com/project/nupibe/domain/route/converter/RouteConverter.java
@@ -1,6 +1,8 @@
 package com.project.nupibe.domain.route.converter;
 
-import com.project.nupibe.domain.route.dto.response.RouteResDTO;
+import com.project.nupibe.domain.route.dto.response.RouteDetailResDTO;
+import com.project.nupibe.domain.route.dto.response.RoutePlacesResDTO;
+import com.project.nupibe.domain.route.dto.response.RouteStoreDTO;
 import com.project.nupibe.domain.route.entity.Route;
 
 import java.util.List;
@@ -8,24 +10,42 @@ import java.util.stream.Collectors;
 
 public class RouteConverter {
 
-    public static RouteResDTO.RouteDetailResponse convertToDto(Route route, List<Object[]> stores) {
-        List<RouteResDTO.StoreSummary> storeSummaries = stores.stream()
-                .map(store -> RouteResDTO.StoreSummary.builder()
-                        .storeId((Long) store[0])
-                        .storeName((String) store[1])
-                        .image((String) store[2])
-                        .build()
-                )
+    public static RouteDetailResDTO.RouteDetailResponse convertToRouteDetailDTO(Route route, List<RouteStoreDTO> storeList) {
+        List<RouteDetailResDTO.StoreSummary> stores = storeList.stream()
+                .map(store -> RouteDetailResDTO.StoreSummary.builder()
+                        .storeId(store.storeId())
+                        .storeName(store.name())
+                        .image(store.image())
+                        .build())
                 .collect(Collectors.toList());
 
-        return RouteResDTO.RouteDetailResponse.builder()
+        return RouteDetailResDTO.RouteDetailResponse.builder()
                 .routeId(route.getId())
                 .routeName(route.getRouteName())
                 .content(route.getContent())
                 .location(route.getLocation())
                 .likeNum(route.getLikeNum())
                 .bookmarkNum(route.getBookmarkNum())
-                .storeList(storeSummaries)
+                .storeList(stores)
+                .build();
+    }
+
+    public static RoutePlacesResDTO.RoutePlacesResponse convertToRoutePlacesDTO(Route route, List<RouteStoreDTO> places) {
+        List<RoutePlacesResDTO.PlaceDetail> placeDetails = places.stream()
+                .map(place -> RoutePlacesResDTO.PlaceDetail.builder()
+                        .storeId(place.storeId())
+                        .name(place.name())
+                        .location(place.location())
+                        .category(place.category())
+                        .order(place.orderIndex())
+                        .distance(place.distance())
+                        .build())
+                .collect(Collectors.toList());
+
+        return RoutePlacesResDTO.RoutePlacesResponse.builder()
+                .routeName(route.getRouteName())
+                .date(route.getDate().toLocalDate().toString())
+                .places(placeDetails)
                 .build();
     }
 }

--- a/src/main/java/com/project/nupibe/domain/route/converter/RouteConverter.java
+++ b/src/main/java/com/project/nupibe/domain/route/converter/RouteConverter.java
@@ -1,0 +1,31 @@
+package com.project.nupibe.domain.route.converter;
+
+import com.project.nupibe.domain.route.dto.response.RouteResDTO;
+import com.project.nupibe.domain.route.entity.Route;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RouteConverter {
+
+    public static RouteResDTO.RouteDetailResponse convertToDto(Route route, List<Object[]> stores) {
+        List<RouteResDTO.StoreSummary> storeSummaries = stores.stream()
+                .map(store -> RouteResDTO.StoreSummary.builder()
+                        .storeId((Long) store[0])
+                        .storeName((String) store[1])
+                        .image((String) store[2])
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        return RouteResDTO.RouteDetailResponse.builder()
+                .routeId(route.getId())
+                .routeName(route.getRouteName())
+                .content(route.getContent())
+                .location(route.getLocation())
+                .likeNum(route.getLikeNum())
+                .bookmarkNum(route.getBookmarkNum())
+                .storeList(storeSummaries)
+                .build();
+    }
+}

--- a/src/main/java/com/project/nupibe/domain/route/dto/response/RouteDetailResDTO.java
+++ b/src/main/java/com/project/nupibe/domain/route/dto/response/RouteDetailResDTO.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 import java.util.List;
 
-public class RouteResDTO {
+public class RouteDetailResDTO {
 
     @Builder
     public record RouteDetailResponse(

--- a/src/main/java/com/project/nupibe/domain/route/dto/response/RoutePlacesResDTO.java
+++ b/src/main/java/com/project/nupibe/domain/route/dto/response/RoutePlacesResDTO.java
@@ -1,0 +1,27 @@
+package com.project.nupibe.domain.route.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public class RoutePlacesResDTO {
+
+    @Builder
+    public record RoutePlacesResponse(
+            String routeName,
+            String date,
+            List<PlaceDetail> places
+    ) {
+    }
+
+    @Builder
+    public record PlaceDetail(
+            Long storeId,
+            String name,
+            String location,
+            String category,
+            int order,
+            String distance
+    ) {
+    }
+}

--- a/src/main/java/com/project/nupibe/domain/route/dto/response/RouteResDTO.java
+++ b/src/main/java/com/project/nupibe/domain/route/dto/response/RouteResDTO.java
@@ -1,0 +1,28 @@
+package com.project.nupibe.domain.route.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public class RouteResDTO {
+
+    @Builder
+    public record RouteDetailResponse(
+            Long routeId,
+            String routeName,
+            String content,
+            String location,
+            int likeNum,
+            int bookmarkNum,
+            List<StoreSummary> storeList
+    ) {
+    }
+
+    @Builder
+    public record StoreSummary(
+            Long storeId,
+            String storeName,
+            String image
+    ) {
+    }
+}

--- a/src/main/java/com/project/nupibe/domain/route/dto/response/RouteStoreDTO.java
+++ b/src/main/java/com/project/nupibe/domain/route/dto/response/RouteStoreDTO.java
@@ -12,4 +12,15 @@ public record RouteStoreDTO(
         String distance, // 거리 정보 (nullable)
         String image
 ) {
+    public RouteStoreDTO withDistance(String distance) {
+        return new RouteStoreDTO(
+                this.storeId,
+                this.name,
+                this.location,
+                this.category,
+                this.orderIndex,
+                distance,
+                this.image
+        );
+    }
 }

--- a/src/main/java/com/project/nupibe/domain/route/dto/response/RouteStoreDTO.java
+++ b/src/main/java/com/project/nupibe/domain/route/dto/response/RouteStoreDTO.java
@@ -1,0 +1,15 @@
+package com.project.nupibe.domain.route.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record RouteStoreDTO(
+        Long storeId,
+        String name,
+        String location,
+        String category,
+        Integer orderIndex,
+        String distance, // 거리 정보 (nullable)
+        String image
+) {
+}

--- a/src/main/java/com/project/nupibe/domain/route/exception/RouteErrorCode.java
+++ b/src/main/java/com/project/nupibe/domain/route/exception/RouteErrorCode.java
@@ -1,0 +1,18 @@
+package com.project.nupibe.domain.route.exception;
+
+import com.project.nupibe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RouteErrorCode implements BaseErrorCode {
+
+    ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "Route404_0", "해당 경로를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/nupibe/domain/route/exception/RouteException.java
+++ b/src/main/java/com/project/nupibe/domain/route/exception/RouteException.java
@@ -1,0 +1,12 @@
+package com.project.nupibe.domain.route.exception;
+
+import com.project.nupibe.global.apiPayload.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class RouteException extends CustomException {
+
+    public RouteException(RouteErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/nupibe/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/project/nupibe/domain/route/repository/RouteRepository.java
@@ -1,0 +1,8 @@
+package com.project.nupibe.domain.route.repository;
+
+import com.project.nupibe.domain.route.entity.Route;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteRepository extends JpaRepository<Route, Long> {
+
+}

--- a/src/main/java/com/project/nupibe/domain/route/service/query/RouteQueryService.java
+++ b/src/main/java/com/project/nupibe/domain/route/service/query/RouteQueryService.java
@@ -1,0 +1,33 @@
+package com.project.nupibe.domain.route.service.query;
+
+import com.project.nupibe.domain.route.converter.RouteConverter;
+import com.project.nupibe.domain.route.dto.response.RouteResDTO;
+import com.project.nupibe.domain.route.entity.Route;
+import com.project.nupibe.domain.route.exception.RouteErrorCode;
+import com.project.nupibe.domain.route.exception.RouteException;
+import com.project.nupibe.domain.route.repository.RouteRepository;
+import com.project.nupibe.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RouteQueryService {
+
+    private final RouteRepository routeRepository;
+    private final StoreRepository storeRepository;
+
+    public RouteResDTO.RouteDetailResponse getRouteDetail(Long routeId) {
+        Route route = routeRepository.findById(routeId)
+                .orElseThrow(() -> new RouteException(RouteErrorCode.ROUTE_NOT_FOUND));
+
+        List<Object[]> storeList = storeRepository.findStoresByRouteId(routeId);
+
+        return RouteConverter.convertToDto(route, storeList);
+    }
+
+}

--- a/src/main/java/com/project/nupibe/domain/store/entity/Store.java
+++ b/src/main/java/com/project/nupibe/domain/store/entity/Store.java
@@ -3,6 +3,7 @@ package com.project.nupibe.domain.store.entity;
 import com.project.nupibe.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.locationtech.jts.geom.Point;
 
 @Entity
 @Getter
@@ -57,4 +58,7 @@ public class Store extends BaseEntity {
 
     @Column(name = "longitude", nullable = false)
     private float longitude;
+
+    @Column(columnDefinition = "geometry(Point, 4326)")
+    private Point coordinates; // PostGIS Point 타입
 }

--- a/src/main/java/com/project/nupibe/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/project/nupibe/domain/store/repository/StoreRepository.java
@@ -21,21 +21,25 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     """)
     List<RouteStoreDTO> findStoresByRouteId(@Param("routeId") Long routeId);
 
-    @Query("""
-        SELECT new com.project.nupibe.domain.route.dto.response.RouteStoreDTO(
-                   s.id, s.name, s.location, s.category, rs.orderIndex,
-                   CASE
-                       WHEN prev.store.coordinates IS NOT NULL THEN 
-                           CAST(ST_DistanceSphere(prev.store.coordinates, s.coordinates) AS string)
-                       ELSE '첫번째장소'
-                   END,
-                   s.image
-               )
-        FROM RouteStore rs
-        JOIN rs.store s
-        LEFT JOIN RouteStore prev ON prev.route.id = rs.route.id AND prev.orderIndex = rs.orderIndex - 1
-        WHERE rs.route.id = :routeId
-        ORDER BY rs.orderIndex ASC
-    """)
-    List<RouteStoreDTO> findStoresWithCalculatedDistance(@Param("routeId") Long routeId);
+    @Query(value = """
+    SELECT 
+        s1.id AS storeId,
+        s1.name AS name,
+        s1.location AS location,
+        s1.category AS category,
+        rs1.order_index AS orderIndex,
+        CASE
+            WHEN s2.coordinates IS NOT NULL THEN
+                ST_DistanceSphere(s2.coordinates, s1.coordinates)
+            ELSE NULL
+        END AS distance,
+        s1.image AS image
+    FROM route_store rs1
+    JOIN store s1 ON rs1.store_id = s1.id
+    LEFT JOIN route_store rs2 ON rs2.route_id = rs1.route_id AND rs2.order_index = rs1.order_index - 1
+    LEFT JOIN store s2 ON rs2.store_id = s2.id
+    WHERE rs1.route_id = :routeId
+    ORDER BY rs1.order_index
+""", nativeQuery = true)
+    List<Object[]> findStoresWithCalculatedDistance(@Param("routeId") Long routeId);
 }

--- a/src/main/java/com/project/nupibe/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/project/nupibe/domain/store/repository/StoreRepository.java
@@ -1,5 +1,6 @@
 package com.project.nupibe.domain.store.repository;
 
+import com.project.nupibe.domain.route.dto.response.RouteStoreDTO;
 import com.project.nupibe.domain.store.entity.Store;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,9 +10,32 @@ import java.util.List;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
-    @Query("SELECT s.id, s.name, s.image FROM RouteStore rs " +
-            "JOIN rs.store s " +
-            "WHERE rs.route.id = :routeId " +
-            "ORDER BY rs.orderIndex ASC")
-    List<Object[]> findStoresByRouteId(@Param("routeId") Long routeId);
+    @Query("""
+        SELECT new com.project.nupibe.domain.route.dto.response.RouteStoreDTO(
+                   s.id, s.name, null, null, rs.orderIndex, null, s.image
+               )
+        FROM RouteStore rs
+        JOIN rs.store s
+        WHERE rs.route.id = :routeId
+        ORDER BY rs.orderIndex ASC
+    """)
+    List<RouteStoreDTO> findStoresByRouteId(@Param("routeId") Long routeId);
+
+    @Query("""
+        SELECT new com.project.nupibe.domain.route.dto.response.RouteStoreDTO(
+                   s.id, s.name, s.location, s.category, rs.orderIndex,
+                   CASE
+                       WHEN prev.store.coordinates IS NOT NULL THEN 
+                           CAST(ST_DistanceSphere(prev.store.coordinates, s.coordinates) AS string)
+                       ELSE '첫번째장소'
+                   END,
+                   s.image
+               )
+        FROM RouteStore rs
+        JOIN rs.store s
+        LEFT JOIN RouteStore prev ON prev.route.id = rs.route.id AND prev.orderIndex = rs.orderIndex - 1
+        WHERE rs.route.id = :routeId
+        ORDER BY rs.orderIndex ASC
+    """)
+    List<RouteStoreDTO> findStoresWithCalculatedDistance(@Param("routeId") Long routeId);
 }

--- a/src/main/java/com/project/nupibe/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/project/nupibe/domain/store/repository/StoreRepository.java
@@ -1,0 +1,17 @@
+package com.project.nupibe.domain.store.repository;
+
+import com.project.nupibe.domain.store.entity.Store;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+    @Query("SELECT s.id, s.name, s.image FROM RouteStore rs " +
+            "JOIN rs.store s " +
+            "WHERE rs.route.id = :routeId " +
+            "ORDER BY rs.orderIndex ASC")
+    List<Object[]> findStoresByRouteId(@Param("routeId") Long routeId);
+}


### PR DESCRIPTION
# ☝️Issue Number

- #9 

##  📌 개요

- 경로 조회 , 경로 내 장소 목록 조회 API
- Store 테이블에 coordinates 필드 추가

## 🔁 변경 사항
87c56c54ca1bbf87aad454e737be46a6ac6b9254
- 경로 상세 조회 API 개발

deb8a5f9f6ae78f2691a4e9745688767c55abf88
- 경로 내 장소 목록 조회 API 개발(수정하기 전)

3a34318f7cd05b6a4f4f3632f8a59f267b69a19e
- 경로 내 장소 목록 조회 API 코드 리팩토링(메서드 분리 및 네이티브 쿼리로 변경)

## 📸 스크린샷

### 경로 상세 조회 API TEST
<img width="1419" alt="1" src="https://github.com/user-attachments/assets/1438a916-91df-460a-8e59-14b28b3aed6e" />
<img width="1416" alt="2" src="https://github.com/user-attachments/assets/3fc70c10-2f9a-467e-9130-f0dfe477c166" />

### 경로 내 장소 목록 조회 API TEST
<img width="1423" alt="3" src="https://github.com/user-attachments/assets/3c077d1f-34f5-411a-b358-8b914988974c" />
<img width="1418" alt="4" src="https://github.com/user-attachments/assets/b9457e1f-f8f6-4cb6-bdea-927c2ad593a1" />

### coordinates 필드 추가 및 좌표값 변환
<img width="613" alt="5" src="https://github.com/user-attachments/assets/47f0bfe3-1b4d-4f44-9a77-45ea2e323462" />


## 👀 기타 더 이야기해볼 점
PostGIS를 사용하는 경우 latitude와 longitude 를 사용하는 것 보다 coordinates 필드로 통합하는 것이 관리와 성능 측면에서 더 효율적이라고 하여서 추가하였습니다.
그 후 기존에 위도 경도를 coordinates 좌표로 바꿔주었습니다.

정리하면
-> PostGIS는 `ST_Distance`, `ST_Intersects` 같은 함수에서 `geometry` 타입을 사용
-> PostGIS는 `latitude`, `longitude` 같은 숫자 타입 필드로는 직접 작업할 수 없고, 대신 이를 `Point`와 같은 `geometry` 객체로 변환