### PR TITLE
Fix: 장소 조회 API 응답형식 변경 + 좋아요&저장 활성화 기능 추가

### DIFF
--- a/src/main/java/com/project/nupibe/domain/member/controller/MypageController.java
+++ b/src/main/java/com/project/nupibe/domain/member/controller/MypageController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -37,11 +34,13 @@ public class MypageController {
         return CustomResponse.onSuccess(responseDto);
     }
 
-    @Operation(method = "GET",summary = "사용자 저장 경로 조회", description = "memberId값을 가지고 저장한 경로들의 목록을 조회합니다.")
-    @GetMapping("{memberId}/routes")
-    public CustomResponse<MypageResponseDTO.MypageRoutesDTO> getBookmarkRoute(@PathVariable("memberId") Long id){
-        MypageResponseDTO.MypageRoutesDTO responseDto = mypageService.getMemberRoute(id);
-        return CustomResponse.onSuccess(responseDto);
+    @Operation(method = "GET", summary = "사용자 저장 경로 조회", description = "memberId값과 routeType을 받아 저장한 경로들의 목록을 조회합니다.")
+    @GetMapping("/{memberId}/routes")
+    public CustomResponse<MypageResponseDTO.MypageRoutesDTO> getBookmarkRoute(
+            @PathVariable("memberId") Long memberId,
+            @RequestParam(value = "routeType", required = true, defaultValue = "created") String routeType) {
+        MypageResponseDTO.MypageRoutesDTO routes = mypageService.getMemberRoute(memberId, routeType);
+        return CustomResponse.onSuccess(routes);
     }
 
 

--- a/src/main/java/com/project/nupibe/domain/member/controller/MypageController.java
+++ b/src/main/java/com/project/nupibe/domain/member/controller/MypageController.java
@@ -29,8 +29,8 @@ public class MypageController {
 
     @Operation(method = "GET",summary = "사용자 저장 장소 조회", description = "memberId값을 가지고 저장한 장소들의 목록을 조회합니다.")
     @GetMapping("{memberId}/stores")
-    public CustomResponse<MypageResponseDTO.MypageStoresDTO> getBookmarkStore(@PathVariable("memberId") Long id){
-        MypageResponseDTO.MypageStoresDTO responseDto = mypageService.getMemberStore(id);
+    public CustomResponse<MypageResponseDTO.MypageStoresDTO> getBookmarkStore(@PathVariable("memberId") Long memberId){
+        MypageResponseDTO.MypageStoresDTO responseDto = mypageService.getMemberStore(memberId);
         return CustomResponse.onSuccess(responseDto);
     }
 

--- a/src/main/java/com/project/nupibe/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/nupibe/domain/member/converter/MemberConverter.java
@@ -26,8 +26,10 @@ public class MemberConverter {
     // Store Entity -> MemberStoreDTO
     public static MypageResponseDTO.MemberStoreDTO toMemberStoreDTO(Store store) {
         return MypageResponseDTO.MemberStoreDTO.builder()
+                .storeId(store.getId())
                 .name(store.getName())
                 .location(store.getLocation())
+                .storePic(store.getImage())
                 .build();
     }
 

--- a/src/main/java/com/project/nupibe/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/nupibe/domain/member/converter/MemberConverter.java
@@ -7,6 +7,7 @@ import com.project.nupibe.domain.store.entity.Store;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,19 +40,26 @@ public class MemberConverter {
 
 
 
-    // Route Entity -> MemberRouteDTO
-    public static MypageResponseDTO.MemberRouteDTO toMemberRouteDTO(Route route) {
+    public static MypageResponseDTO.MemberRouteDTO toMemberRouteDTO(Route route, String image) {
         return MypageResponseDTO.MemberRouteDTO.builder()
+                .routeId(route.getId())
                 .name(route.getRouteName())
                 .location(route.getLocation())
+                .routePic(image)
                 .build();
     }
 
-    // List<Route> -> List<MemberRouteDTO>
-    public static List<MypageResponseDTO.MemberRouteDTO> toMemberRouteDTOList(List<Route> routes) {
-        return routes.stream()
-                .map(MemberConverter::toMemberRouteDTO) // Route를 DTO로 변환
-                .collect(Collectors.toList());
+    public static MypageResponseDTO.MypageRoutesDTO toMypageRoutesDTO(List<Route> routes, List<String> images) {
+        List<MypageResponseDTO.MemberRouteDTO> routeList = new ArrayList<>();
+
+        for (int i = 0; i < routes.size(); i++) {
+            MypageResponseDTO.MemberRouteDTO route = toMemberRouteDTO(routes.get(i), images.get(i));
+            routeList.add(route);
+        }
+
+        return MypageResponseDTO.MypageRoutesDTO.builder()
+                .routes(routeList)
+                .build();
     }
 
 }

--- a/src/main/java/com/project/nupibe/domain/member/dto/response/MypageResponseDTO.java
+++ b/src/main/java/com/project/nupibe/domain/member/dto/response/MypageResponseDTO.java
@@ -24,15 +24,17 @@ public class MypageResponseDTO{
     ){}
 
     @Builder
-    public record MemberRouteDTO (
+    public record MemberRouteDTO(
+            Long routeId,
             String name,
-            String location
-    ){}
+            String location,
+            String routePic
+    ) {}
 
     @Builder
-    public record MypageRoutesDTO (
-            List<MemberRouteDTO> bookmarkedRoutes
-    ){}
+    public record MypageRoutesDTO(
+            List<MemberRouteDTO> routes
+    ) {}
 
 
 

--- a/src/main/java/com/project/nupibe/domain/member/dto/response/MypageResponseDTO.java
+++ b/src/main/java/com/project/nupibe/domain/member/dto/response/MypageResponseDTO.java
@@ -14,8 +14,10 @@ public class MypageResponseDTO{
 
     @Builder
     public record MemberStoreDTO (
+            Long storeId,
             String name,
-            String location
+            String location,
+            String storePic
     ){}
 
     @Builder

--- a/src/main/java/com/project/nupibe/domain/route/controller/RouteController.java
+++ b/src/main/java/com/project/nupibe/domain/route/controller/RouteController.java
@@ -37,14 +37,15 @@ public class RouteController {
 
     @GetMapping("/{routeId}")
     @Operation(summary = "경로 상세 조회 API", description = "PathVariable로 보낸 id의 경로를 상세 조회 합니다.")
-    public CustomResponse<RouteDetailResDTO.RouteDetailResponse> getRouteDetail(@PathVariable Long routeId) {
-        RouteDetailResDTO.RouteDetailResponse response = routeQueryService.getRouteDetail(routeId);
+    public CustomResponse<RouteDetailResDTO.RouteDetailResponse> getRouteDetail(@PathVariable("routeId") Long routeId,
+                                                                                @RequestParam(required = false) Long memberId) {
+        RouteDetailResDTO.RouteDetailResponse response = routeQueryService.getRouteDetail(routeId,memberId);
         return CustomResponse.onSuccess(response);
     }
 
     @GetMapping("/{routeId}/stores")
     @Operation(summary = "경로 내 장소 목록 조회 API", description = "PathVariable로 보낸 id의 경로 내 장소들을 조회 합니다.")
-    public CustomResponse<RoutePlacesResDTO.RoutePlacesResponse> getRoutePlaces(@PathVariable Long routeId) {
+    public CustomResponse<RoutePlacesResDTO.RoutePlacesResponse> getRoutePlaces(@PathVariable Long routeId){
         RoutePlacesResDTO.RoutePlacesResponse response = routeQueryService.getRoutePlaces(routeId);
         return CustomResponse.onSuccess(response);
     }

--- a/src/main/java/com/project/nupibe/domain/route/converter/RouteConverter.java
+++ b/src/main/java/com/project/nupibe/domain/route/converter/RouteConverter.java
@@ -13,7 +13,8 @@ import java.util.stream.Collectors;
 
 public class RouteConverter {
 
-    public static RouteDetailResDTO.RouteDetailResponse convertToRouteDetailDTO(Route route, List<RouteStoreDTO> storeList) {
+    public static RouteDetailResDTO.RouteDetailResponse convertToRouteDetailDTO(
+            Route route, boolean isLiked, boolean isBookmarked, List<RouteStoreDTO> storeList) {
         List<RouteDetailResDTO.StoreSummary> stores = storeList.stream()
                 .map(store -> RouteDetailResDTO.StoreSummary.builder()
                         .storeId(store.storeId())
@@ -29,6 +30,8 @@ public class RouteConverter {
                 .location(route.getLocation())
                 .likeNum(route.getLikeNum())
                 .bookmarkNum(route.getBookmarkNum())
+                .isLiked(isLiked)
+                .isBookmarked(isBookmarked)
                 .storeList(stores)
                 .build();
     }

--- a/src/main/java/com/project/nupibe/domain/route/dto/response/RouteDetailResDTO.java
+++ b/src/main/java/com/project/nupibe/domain/route/dto/response/RouteDetailResDTO.java
@@ -14,6 +14,8 @@ public class RouteDetailResDTO {
             String location,
             int likeNum,
             int bookmarkNum,
+            Boolean isLiked,
+            Boolean isBookmarked,
             List<StoreSummary> storeList
     ) {
     }

--- a/src/main/java/com/project/nupibe/domain/store/controller/StoreController.java
+++ b/src/main/java/com/project/nupibe/domain/store/controller/StoreController.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -37,6 +39,14 @@ public class StoreController {
     public CustomResponse<StoreResponseDTO.MemberRouteListDTO> getRoutesByStoreId(@PathVariable("storeId") Long storeId) {
         StoreResponseDTO.MemberRouteListDTO routes = storeCommandService.getRoutesByStoreId(storeId);
         return CustomResponse.onSuccess(routes);
+    }
+
+    @GetMapping("/{storeId}/images")
+    @Operation(method = "GET", summary = "특정 가게의 이미지들 조회", description = "상세페이지 조회 내 사진 탭 기능입니다.")
+    public CustomResponse<StoreResponseDTO.StoreImagesDTO> getTabImages(@PathVariable("storeId") Long storeId) {
+        StoreResponseDTO.StoreImagesDTO storeImagesDTO = storeQueryService.getTabImages(storeId);
+        return CustomResponse.onSuccess(storeImagesDTO);
+
     }
 
     @PostMapping("{storeId}/bookmark")

--- a/src/main/java/com/project/nupibe/domain/store/controller/StoreController.java
+++ b/src/main/java/com/project/nupibe/domain/store/controller/StoreController.java
@@ -25,8 +25,10 @@ public class StoreController {
 
     @GetMapping("{storeId}/detail")
     @Operation(method = "GET", summary = "장소 단일 조회(detail) API", description = "장소 상세페이지 조회입니다.")
-    public CustomResponse<StoreResponseDTO.StoreDetailResponseDTO> getStoreDetail(@PathVariable("storeId") Long storeId){
-        StoreResponseDTO.StoreDetailResponseDTO responseDTO = storeQueryService.getStoreDetail(storeId);
+    public CustomResponse<StoreResponseDTO.StoreDetailResponseDTO> getStoreDetail(
+            @PathVariable("storeId") Long storeId,
+            @RequestParam(required = false) Long memberId) {
+        StoreResponseDTO.StoreDetailResponseDTO responseDTO = storeQueryService.getStoreDetail(storeId, memberId);
         return CustomResponse.onSuccess(responseDTO);
     }
     @GetMapping("{storeId}/routes")

--- a/src/main/java/com/project/nupibe/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/project/nupibe/domain/store/converter/StoreConverter.java
@@ -19,12 +19,13 @@ public class StoreConverter {
     public static StoreResponseDTO.StoreDetailResponseDTO toStoreDetailResponseDTO(
             Store store,
             boolean isLiked,
-            boolean isBookmarked) {
+            boolean isBookmarked,
+            List<String> images) {
         return StoreResponseDTO.StoreDetailResponseDTO.builder()
                 .id(store.getId())
                 .name(store.getName())
                 .content(store.getContent())
-                .image(store.getImage())
+                .images(images) // 여러 이미지 추가
                 .category(store.getCategory())
                 .like_num(store.getLikeNum())
                 .bookmark_num(store.getBookmarkNum())

--- a/src/main/java/com/project/nupibe/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/project/nupibe/domain/store/converter/StoreConverter.java
@@ -27,8 +27,8 @@ public class StoreConverter {
                 .content(store.getContent())
                 .images(images) // 여러 이미지 추가
                 .category(store.getCategory())
-                .like_num(store.getLikeNum())
-                .bookmark_num(store.getBookmarkNum())
+                .likeNum(store.getLikeNum())
+                .bookmarkNum(store.getBookmarkNum())
                 .isLiked(isLiked)
                 .isBookmarked(isBookmarked)
                 .build();

--- a/src/main/java/com/project/nupibe/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/project/nupibe/domain/store/converter/StoreConverter.java
@@ -16,7 +16,10 @@ import java.util.stream.Collectors;
 public class StoreConverter {
     //entity -> previewDTO
 
-    public static StoreResponseDTO.StoreDetailResponseDTO toStoreDetailResponseDTO(Store store){
+    public static StoreResponseDTO.StoreDetailResponseDTO toStoreDetailResponseDTO(
+            Store store,
+            boolean isLiked,
+            boolean isBookmarked) {
         return StoreResponseDTO.StoreDetailResponseDTO.builder()
                 .id(store.getId())
                 .name(store.getName())
@@ -25,6 +28,8 @@ public class StoreConverter {
                 .category(store.getCategory())
                 .like_num(store.getLikeNum())
                 .bookmark_num(store.getBookmarkNum())
+                .isLiked(isLiked)
+                .isBookmarked(isBookmarked)
                 .build();
     }
     public static StoreResponseDTO.StorePreviewDTO toStorePreviewDto(Store store){

--- a/src/main/java/com/project/nupibe/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/project/nupibe/domain/store/converter/StoreConverter.java
@@ -20,19 +20,29 @@ public class StoreConverter {
             Store store,
             boolean isLiked,
             boolean isBookmarked,
-            List<String> images) {
+            List<String> slideImages) {
         return StoreResponseDTO.StoreDetailResponseDTO.builder()
                 .id(store.getId())
                 .name(store.getName())
                 .content(store.getContent())
-                .images(images) // 여러 이미지 추가
+                .slideImages(slideImages)
                 .category(store.getCategory())
                 .likeNum(store.getLikeNum())
                 .bookmarkNum(store.getBookmarkNum())
                 .isLiked(isLiked)
                 .isBookmarked(isBookmarked)
+                .location(store.getLocation())
+                .address(store.getAddress())
+                .businessHours(store.getBusinessHours())
+                .number(store.getNumber())
+                .snsUrl(store.getSnsUrl())
+                .groupInfo(store.getGroupInfo())
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
                 .build();
     }
+
+
     public static StoreResponseDTO.StorePreviewDTO toStorePreviewDto(Store store){
         return StoreResponseDTO.StorePreviewDTO.builder()
                 .id(store.getId())

--- a/src/main/java/com/project/nupibe/domain/store/dto/response/StoreResponseDTO.java
+++ b/src/main/java/com/project/nupibe/domain/store/dto/response/StoreResponseDTO.java
@@ -26,12 +26,12 @@ public class StoreResponseDTO {
             Long id,
             String name,
             String content,
-            String image,
+            List<String> images,
             String category,
             Integer like_num,
             Integer bookmark_num,
-            boolean isLiked,
-            boolean isBookmarked
+            Boolean isLiked,
+            Boolean isBookmarked
     ) {}
     @Builder
     public record StorePreviewDTO(

--- a/src/main/java/com/project/nupibe/domain/store/dto/response/StoreResponseDTO.java
+++ b/src/main/java/com/project/nupibe/domain/store/dto/response/StoreResponseDTO.java
@@ -22,15 +22,17 @@ public class StoreResponseDTO {
     ){}
 
     @Builder
-    public record StoreDetailResponseDTO (
+    public record StoreDetailResponseDTO(
             Long id,
             String name,
             String content,
             String image,
             String category,
             Integer like_num,
-            Integer bookmark_num){
-    }
+            Integer bookmark_num,
+            boolean isLiked,
+            boolean isBookmarked
+    ) {}
     @Builder
     public record StorePreviewDTO(
             Long id,

--- a/src/main/java/com/project/nupibe/domain/store/dto/response/StoreResponseDTO.java
+++ b/src/main/java/com/project/nupibe/domain/store/dto/response/StoreResponseDTO.java
@@ -26,13 +26,22 @@ public class StoreResponseDTO {
             Long id,
             String name,
             String content,
-            List<String> images,
+            String location,
+            String address,
+            String businessHours,
+            String number,
+            String snsUrl,
+            List<String> slideImages,
             String category,
+            String groupInfo,
             int likeNum,
             int bookmarkNum,
             Boolean isLiked,
-            Boolean isBookmarked
+            Boolean isBookmarked,
+            float latitude,
+            float longitude
     ) {}
+
     @Builder
     public record StorePreviewDTO(
             Long id,
@@ -56,4 +65,10 @@ public class StoreResponseDTO {
             Long storeId,
             boolean saved
     ) {};
+
+
+    public record StoreImagesDTO(
+            Long storeId,
+            List<String> tabImages
+    ) {}
 }

--- a/src/main/java/com/project/nupibe/domain/store/dto/response/StoreResponseDTO.java
+++ b/src/main/java/com/project/nupibe/domain/store/dto/response/StoreResponseDTO.java
@@ -28,8 +28,8 @@ public class StoreResponseDTO {
             String content,
             List<String> images,
             String category,
-            Integer like_num,
-            Integer bookmark_num,
+            int likeNum,
+            int bookmarkNum,
             Boolean isLiked,
             Boolean isBookmarked
     ) {}

--- a/src/main/java/com/project/nupibe/domain/store/entity/ImageType.java
+++ b/src/main/java/com/project/nupibe/domain/store/entity/ImageType.java
@@ -1,0 +1,6 @@
+package com.project.nupibe.domain.store.entity;
+
+public enum ImageType {
+    MAIN, // 슬라이드용 이미지
+    TAB   // TAB에서 보여줄 이미지 (기존 Images)
+}

--- a/src/main/java/com/project/nupibe/domain/store/entity/Store.java
+++ b/src/main/java/com/project/nupibe/domain/store/entity/Store.java
@@ -6,6 +6,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.locationtech.jts.geom.Point;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -70,6 +73,9 @@ public class Store extends BaseEntity {
 
     @Column(columnDefinition = "geography(Point, 4326)")
     private Point coordinates1; // PostGIS Point 타입
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StoreImage> images = new ArrayList<>();
 
     public void setBookmarkNum(int i) {
         this.bookmarkNum = i;

--- a/src/main/java/com/project/nupibe/domain/store/entity/Store.java
+++ b/src/main/java/com/project/nupibe/domain/store/entity/Store.java
@@ -74,8 +74,8 @@ public class Store extends BaseEntity {
     @Column(columnDefinition = "geography(Point, 4326)")
     private Point coordinates1; // PostGIS Point 타입
 
-    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<StoreImage> images = new ArrayList<>();
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<StoreImage> images;
 
     public void setBookmarkNum(int i) {
         this.bookmarkNum = i;

--- a/src/main/java/com/project/nupibe/domain/store/entity/StoreImage.java
+++ b/src/main/java/com/project/nupibe/domain/store/entity/StoreImage.java
@@ -22,5 +22,9 @@ public class StoreImage {
 
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
+
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ImageType type; // MAIN,TAB
 }
 

--- a/src/main/java/com/project/nupibe/domain/store/entity/StoreImage.java
+++ b/src/main/java/com/project/nupibe/domain/store/entity/StoreImage.java
@@ -1,0 +1,26 @@
+package com.project.nupibe.domain.store.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "store_image")
+public class StoreImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+}
+

--- a/src/main/java/com/project/nupibe/domain/store/service/StoreQueryService.java
+++ b/src/main/java/com/project/nupibe/domain/store/service/StoreQueryService.java
@@ -9,6 +9,7 @@ import com.project.nupibe.domain.member.repository.StoreLikeRepository;
 import com.project.nupibe.domain.store.converter.StoreConverter;
 import com.project.nupibe.domain.store.dto.response.StoreResponseDTO;
 import com.project.nupibe.domain.store.entity.Store;
+import com.project.nupibe.domain.store.entity.StoreImage;
 import com.project.nupibe.domain.store.entity.StoreSearchQuery;
 import com.project.nupibe.domain.store.exception.code.StoreErrorCode;
 import com.project.nupibe.domain.store.exception.handler.StoreException;
@@ -21,6 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -49,8 +52,12 @@ public class StoreQueryService {
             // 북마크 여부 확인
             isBookmarked = memberStoreRepository.existsByMemberIdAndStoreId(memberId, storeId);
         }
+        // 이미지 URL 리스트 생성
+        List<String> images = store.getImages().stream()
+                .map(StoreImage::getImageUrl)
+                .collect(Collectors.toList());
 
-        return StoreConverter.toStoreDetailResponseDTO(store, isLiked, isBookmarked);
+        return StoreConverter.toStoreDetailResponseDTO(store, isLiked, isBookmarked, images);
     }
 
     //단일 가게 조회(preview)

--- a/src/main/java/com/project/nupibe/domain/store/service/StoreQueryService.java
+++ b/src/main/java/com/project/nupibe/domain/store/service/StoreQueryService.java
@@ -1,5 +1,11 @@
 package com.project.nupibe.domain.store.service;
 
+import com.project.nupibe.domain.member.entity.Member;
+import com.project.nupibe.domain.member.exception.code.MemberErrorCode;
+import com.project.nupibe.domain.member.exception.handler.MemberException;
+import com.project.nupibe.domain.member.repository.MemberRepository;
+import com.project.nupibe.domain.member.repository.MemberStoreRepository;
+import com.project.nupibe.domain.member.repository.StoreLikeRepository;
 import com.project.nupibe.domain.store.converter.StoreConverter;
 import com.project.nupibe.domain.store.dto.response.StoreResponseDTO;
 import com.project.nupibe.domain.store.entity.Store;
@@ -21,13 +27,30 @@ import java.util.ArrayList;
 @RequiredArgsConstructor
 public class StoreQueryService {
     private final StoreRepository storeRepository;
+    private final StoreLikeRepository storeLikeRepository;
+    private final MemberStoreRepository memberStoreRepository;
+    private final MemberRepository memberRepository;
+
+
     private final int RADIUS = 1000; //1km 반경에 있는 가게 조회
 
     //단일 가게 조회(detail)
-    public StoreResponseDTO.StoreDetailResponseDTO getStoreDetail(Long storeId) {
+    public StoreResponseDTO.StoreDetailResponseDTO getStoreDetail(Long storeId, Long memberId) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
-        return StoreConverter.toStoreDetailResponseDTO(store);
+
+        boolean isLiked = false;
+        boolean isBookmarked = false;
+
+        if (memberId != null) {
+            // 좋아요 여부 확인
+            isLiked = storeLikeRepository.existsByMemberIdAndStoreId(memberId, storeId);
+
+            // 북마크 여부 확인
+            isBookmarked = memberStoreRepository.existsByMemberIdAndStoreId(memberId, storeId);
+        }
+
+        return StoreConverter.toStoreDetailResponseDTO(store, isLiked, isBookmarked);
     }
 
     //단일 가게 조회(preview)

--- a/src/main/java/com/project/nupibe/domain/store/service/StoreQueryService.java
+++ b/src/main/java/com/project/nupibe/domain/store/service/StoreQueryService.java
@@ -32,7 +32,6 @@ public class StoreQueryService {
     private final StoreRepository storeRepository;
     private final StoreLikeRepository storeLikeRepository;
     private final MemberStoreRepository memberStoreRepository;
-    private final MemberRepository memberRepository;
 
 
     private final int RADIUS = 1000; //1km 반경에 있는 가게 조회


### PR DESCRIPTION
# ☝️Issue Number

- #56 

##  📌 개요

## 🔁 변경 사항
[사진관련]
StoreImage 테이블 추가했습니다.
테이블에 type필드 추가해서 어느 부분에서 보여질 사진인지 구분했습니다. 
기존 image필드는 대표사진으로 그대로 유지중입니다.
따라서 다른 API를 수정할 필요는 없습니다.

[좋아요&저장 활성화 관련]
경로, 장소 둘 다 수정해 둔 상태입니다.
memberId를 requestParam으로 받도록 추가했습니다.

[마이페이지 조회 관련]
나의 경로 API와 같게 경로 조회와  장소조회 응답형식을 수정했습니다.

## 📸 스크린샷
![ㅇㄷㅅ먀ㅣ ](https://github.com/user-attachments/assets/31a9a66c-9238-4d93-916d-43f104c40d47)


## 👀 기타 더 이야기해볼 점